### PR TITLE
set content-length when responding from TwitterHandler

### DIFF
--- a/src/main/scala/com/twitter/server/handler/TwitterHandler.scala
+++ b/src/main/scala/com/twitter/server/handler/TwitterHandler.scala
@@ -12,6 +12,7 @@ trait TwitterHandler extends Service[HttpRequest, HttpResponse] {
 
   def respond(msg: String) = {
     val response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK)
+    response.setHeader("Content-Length", msg.getBytes.length)
     response.setContent(ChannelBuffers.wrappedBuffer(msg.getBytes))
     Future.value(response)
   }


### PR DESCRIPTION
The AWS Elastic Load Balancer health check expects the Content-Length header to be set. So in order to make Twitter-Server's /health lifecycle page work for the AWS load balancer it needs to specify Content-Length.
