### PR TITLE
Change how jvm/gc/msec is reported in the UI.

### DIFF
--- a/src/main/resources/twitter-server/js/summary.js
+++ b/src/main/resources/twitter-server/js/summary.js
@@ -23,7 +23,7 @@ function loadProcInfo() {
   function pretty(name, value) {
     if (name === "jvm/uptime") return msToStr.convert(value)
     else if (name === "jvm/mem/current/used") return bytesToStr.convert(value)
-    else if (name === "jvm/gc/msec") return bytesToStr.convert(value)+"/ms"
+    else if (name === "jvm/gc/msec") return msToStr.convert(value)
     else return value
   }
 


### PR DESCRIPTION
Problem:
It is confusing to display on the UI that you're GC'ing at a certain rate, when the number you're actually displaying is how much time you've spent in GC overall. It has led engineers to jump to wrong conclusions about their systems.

Solution:
Change from displaying as amount GC'd per ms to displaying it as total amount of time spent GC'ing.

Result:
Reduce the confusion.