### PR TITLE
fix handling of clients and servers with slashes

### DIFF
--- a/src/main/scala/com/twitter/server/handler/ClientRegistryHandler.scala
+++ b/src/main/scala/com/twitter/server/handler/ClientRegistryHandler.scala
@@ -141,9 +141,9 @@ class ClientRegistryHandler(
           content = Buf.Utf8(html)
         )
 
-      case name =>
-        val entries = registry.registrants filter { _.name == name }
-        if (entries.isEmpty) new404(s"$name could not be found.") else {
+      case _ =>
+        val entries = registry.registrants filter { r => path.endsWith(r.name) }
+        if (entries.isEmpty) new404(s"$path could not be found.") else {
           val client = entries.head
           val scope = findClientScope(client.name)
           val html = StackRegistryView.render(client, scope)

--- a/src/main/scala/com/twitter/server/handler/ServerRegistryHandler.scala
+++ b/src/main/scala/com/twitter/server/handler/ServerRegistryHandler.scala
@@ -97,9 +97,9 @@ class ServerRegistryHandler(
           content = Buf.Utf8(html)
         )
 
-      case name =>
-        val entries = registry.registrants filter { _.name == name }
-        if (entries.isEmpty) new404(s"$name could not be found.") else {
+      case _ =>
+        val entries = registry.registrants filter { r => path.endsWith(r.name) }
+        if (entries.isEmpty) new404(s"$path could not be found.") else {
           val server = entries.head
           val scope = findScope(server.name)
           val html = StackRegistryView.render(server, scope)

--- a/src/test/scala/com/twitter/server/handler/ClientRegistryHandlerTest.scala
+++ b/src/test/scala/com/twitter/server/handler/ClientRegistryHandlerTest.scala
@@ -34,6 +34,21 @@ class ClientRegistryHandlerTest extends FunSuite {
     assert(res1.status === Status.NotFound)
   }
 
+  test("query a client with a forward slash") {
+    val metricsCtx = new MetricSourceTest.Ctx
+    import metricsCtx._
+
+    val registry = new StackRegistry { def registryName: String = "client" }
+    registry.register("localhost:8080", StackClient.newStack, Stack.Params.empty + param.Label("client0/test"))
+    val handler = new ClientRegistryHandler(source, registry)
+
+    val res = Await.result(handler(Request("/client0/test")))
+    assert(res.status === Status.Ok)
+    val content = res.contentString
+    assert(content.contains("client0/test"))
+    assert(content.contains("localhost:8080"))
+  }
+
   test("client profile") {
     Time.withCurrentTimeFrozen { tc =>
       val metricsCtx = new MetricSourceTest.Ctx

--- a/src/test/scala/com/twitter/server/handler/ServerRegistryHandlerTest.scala
+++ b/src/test/scala/com/twitter/server/handler/ServerRegistryHandlerTest.scala
@@ -30,4 +30,19 @@ class ServerRegistryHandlerTest extends FunSuite {
     val res1 = Await.result(handler(http.Request("/server1")))
     assert(res1.status === http.Status.NotFound)
   }
+
+  test("query a server with a slash") {
+    val metricsCtx = new MetricSourceTest.Ctx
+    import metricsCtx._
+
+    val registry = new StackRegistry { def registryName: String = "server" }
+    registry.register(":8080", StackServer.newStack, Stack.Params.empty + param.Label("server0/test"))
+    val handler = new ServerRegistryHandler(source, registry)
+
+    val res = Await.result(handler(http.Request("/server0/test")))
+    assert(res.status === http.Status.Ok)
+    val content = res.contentString
+    assert(content.contains("server0/test"))
+    assert(content.contains(":8080"))
+  }
 }


### PR DESCRIPTION
twitter-server's admin route handling fails for clients and servers that contain slashes in the name.

For example:
This works: /admin/clients/foo
This gives 404: /admin/clients/foo/bar
