### PR TITLE
fix metrics page for stats with special characters

### DIFF
--- a/src/main/resources/twitter-server/js/metric-query.js
+++ b/src/main/resources/twitter-server/js/metric-query.js
@@ -33,7 +33,12 @@ function graphLibLoaded() {
 
   $('#metrics li').on('click', function(e) { render($(e.target)) })
 
-  var fragmentId = $("#"+window.location.hash.replace('#', '').replace(/\//g, "-"))
+  var fragmentId = $("#"+window.location.hash
+    .replace('#', '')
+    .replace(/\//g, "-")
+    // css chars to escape: !"#$%&'()*+,-./:;<=>?@[\]^`{|}~
+    .replace(/(!|"|#|%|&|'|\(|\)|\*|\+|,|-|\.|\/|:|;|<|=|>|\?|@|\[|\\|\]|\^|`|{|\||}|~)/g, "\\$1")
+  )
   if (fragmentId[0] != undefined) {
     $(fragmentId)[0].scrollIntoView(true)
     render(fragmentId)


### PR DESCRIPTION
jquery's css selectors need some special characters escaped,
for example, given a client named "foo.bar":
/admin/metrics#clnt/foo.bar/requests does not work
/admin/metrics#clnt/foo\.bar/requests works