### PR TITLE
Introduce a twitter-server dependency on util-events

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -119,6 +119,7 @@ object TwitterServer extends Build {
       finagle("zipkin"),
       util("app"),
       util("core"),
+      util("events"),
       util("jvm"),
       util("lint"),
       util("logging"),


### PR DESCRIPTION
Problem

When building a basic TwitterServer application, a runtime error is encountered
on first run:

    java.lang.NoClassDefFoundError: com/twitter/util/events/Event$Type
      at com.twitter.server.EventSink$$anonfun$1.apply$mcV$sp(EventSink.scala:34)

Solution

Add a dependency on util-events