### PR TITLE
Remove LogFormat trait from TwitterServer

### DIFF
--- a/src/main/scala/com/twitter/server/LogFormat.scala
+++ b/src/main/scala/com/twitter/server/LogFormat.scala
@@ -9,13 +9,13 @@ import java.io.{PrintWriter, StringWriter}
 import scala.reflect.NameTransformer
 
 trait LogFormat { app: App with Logging =>
-  override def defaultFormatter = new LogFormatter
+  override def defaultFormatter: Formatter = new LogFormatter
 }
 
 /**
  * Implements "glog" style log formatting.
  */
-class LogFormatter extends Formatter {
+final class LogFormatter extends Formatter {
   private val levels = Map[Level, Char](
     Level.FINEST -> 'D',
     Level.FINER -> 'D',

--- a/src/main/scala/com/twitter/server/LogFormat.scala
+++ b/src/main/scala/com/twitter/server/LogFormat.scala
@@ -10,6 +10,9 @@ import scala.reflect.NameTransformer
 
 trait LogFormat { app: App with Logging =>
   override def defaultFormatter: Formatter = new LogFormatter
+  premain {
+    configureLoggerFactories()
+  }
 }
 
 /**

--- a/src/main/scala/com/twitter/server/LogFormat.scala
+++ b/src/main/scala/com/twitter/server/LogFormat.scala
@@ -2,23 +2,20 @@ package com.twitter.server
 
 import com.twitter.app.App
 import com.twitter.finagle.tracing.Trace
-import com.twitter.logging.{Level => TwLevel}
+import com.twitter.logging.{ Level => TwLevel, _}
 import com.twitter.util.Time
-import java.util.logging.{Formatter, Level, LogRecord, Logger}
+import java.util.logging.{Level, LogRecord}
 import java.io.{PrintWriter, StringWriter}
 import scala.reflect.NameTransformer
 
-trait LogFormat { app: App =>
-  premain {
-    for (h <- Logger.getLogger("").getHandlers)
-      h.setFormatter(new LogFormatter)
-  }
+trait LogFormat { app: App with Logging =>
+  override def defaultFormatter = new LogFormatter
 }
 
 /**
  * Implements "glog" style log formatting.
  */
-private class LogFormatter extends Formatter {
+class LogFormatter extends Formatter {
   private val levels = Map[Level, Char](
     Level.FINEST -> 'D',
     Level.FINER -> 'D',

--- a/src/main/scala/com/twitter/server/LogFormat.scala
+++ b/src/main/scala/com/twitter/server/LogFormat.scala
@@ -15,7 +15,7 @@ trait LogFormat { app: App with Logging =>
 /**
  * Implements "glog" style log formatting.
  */
-final class LogFormatter extends Formatter {
+private class LogFormatter extends Formatter {
   private val levels = Map[Level, Char](
     Level.FINEST -> 'D',
     Level.FINER -> 'D',

--- a/src/main/scala/com/twitter/server/TwitterServer.scala
+++ b/src/main/scala/com/twitter/server/TwitterServer.scala
@@ -30,7 +30,6 @@ trait TwitterServer extends App
   with Linters
   with Logging
   with EventSink
-  with LogFormat
   with Hooks
   with AdminHttpServer
   with Admin

--- a/src/main/scala/com/twitter/server/TwitterServer.scala
+++ b/src/main/scala/com/twitter/server/TwitterServer.scala
@@ -30,6 +30,7 @@ trait TwitterServer extends App
   with Linters
   with Logging
   with EventSink
+  with LogFormat
   with Hooks
   with AdminHttpServer
   with Admin


### PR DESCRIPTION
Problem

LogFormat bypasses the util Logging and Formatting objects and directly
sets the jul Formatter. This means log messages initial are logged in
the LogFormat format rather than the user define Formatter format. This
simply removes the trait from default TwitterServer without deleting the
trait so that users can add it in later if they want its format.

Solution

Remove LogFormat from the stack of traits TwitterServer extends by default. Leaving the trait so it can be used.

Result

Using an override of the defaultFormatter works after the change.
