### PR TITLE
twitter-server: fix json in doc of Admin.rst

### DIFF
--- a/doc/src/sphinx/Admin.rst
+++ b/doc/src/sphinx/Admin.rst
@@ -234,7 +234,7 @@ detailed in
             "value" : $value,
             "type" : "$class"
          },
-         { <other updates here>
+         { <other updates here> }
       ]
   }
 


### PR DESCRIPTION
Problem

closing bracket is missing.

Solution

add closing bracket.

Result

it will be valid json.

before

![image](https://user-images.githubusercontent.com/1635885/28100720-c9be647e-66fe-11e7-8a59-ae42f8f2ac63.png)

after

![image](https://user-images.githubusercontent.com/1635885/28100694-acf429c8-66fe-11e7-834a-efa0c6004678.png)