### PR TITLE
Drop dependency on finagle zipkin-core

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -121,7 +121,6 @@ lazy val twitterServer = (project in file("server"))
       finagle("http"),
       finagle("toggle"),
       finagle("tunable"),
-      finagle("zipkin-core"),
       util("app"),
       util("core"),
       util("jvm"),


### PR DESCRIPTION
TwitterServer doesn't contains any code depending on it anymore.
It shouldn't affect the runtime since the actual ScribeZipkinTracer is in
finagle zipkin and not zipkin-core