### PR TITLE
[twitter-server] Update histograms docs and admin page to use snake case

### DIFF
--- a/doc/src/sphinx/Features.rst
+++ b/doc/src/sphinx/Features.rst
@@ -307,35 +307,35 @@ There are two endpoints for histograms, `/admin/histograms.json` and `/admin/his
   {
     "clnt/p2cslowservertest-server/request_latency_ms" : [
       {
-        "lowerLimit" : 5,
-        "upperLimit" : 6,
+        "lower_limit" : 5,
+        "upper_limit" : 6,
         "count" : 28
       },
       {
-        "lowerLimit" : 6,
-        "upperLimit" : 7,
+        "lower_limit" : 6,
+        "upper_limit" : 7,
         "count" : 9188
       },
       {
-        "lowerLimit" : 7,
-        "upperLimit" : 8,
+        "lower_limit" : 7,
+        "upper_limit" : 8,
         "count" : 25164
       }
     ],
     "jvm/gc/eden/pause_msec" : [
       {
-        "lowerLimit" : 8,
-        "upperLimit" : 9,
+        "lower_limit" : 8,
+        "upper_limit" : 9,
         "count" : 1
       },
       {
-        "lowerLimit" : 9,
-        "upperLimit" : 10,
+        "lower_limit" : 9,
+        "upper_limit" : 10,
         "count" : 1
       },
       {
-        "lowerLimit" : 53,
-        "upperLimit" : 54,
+        "lower_limit" : 53,
+        "upper_limit" : 54,
         "count" : 1
       }
     ]
@@ -373,18 +373,18 @@ equal to the bucket's upper limit.
   {
     "clnt/p2cslowservertest-server/request_latency_ms" : [
       {
-        "lowerLimit" : 5,
-        "upperLimit" : 6,
+        "lower_limit" : 5,
+        "upper_limit" : 6,
         "count" : 28
       },
       {
-        "lowerLimit" : 6,
-        "upperLimit" : 7,
+        "lower_limit" : 6,
+        "upper_limit" : 7,
         "count" : 9188
       },
       {
-        "lowerLimit" : 7,
-        "upperLimit" : 8,
+        "lower_limit" : 7,
+        "upper_limit" : 8,
         "count" : 25164
       }
     ]
@@ -401,28 +401,28 @@ equal to the bucket's upper limit.
   {
     "clnt/p2cslowservertest-server/request_latency_ms" : [
       {
-        "lowerLimit" : 5,
-        "upperLimit" : 6,
+        "lower_limit" : 5,
+        "upper_limit" : 6,
         "percentage" : 6.444885E-5
       },
       {
-        "lowerLimit" : 6,
-        "upperLimit" : 7,
+        "lower_limit" : 6,
+        "upper_limit" : 7,
         "percentage" : 0.03286891
       },
       {
-        "lowerLimit" : 7,
-        "upperLimit" : 8,
+        "lower_limit" : 7,
+        "upper_limit" : 8,
         "percentage" : 0.15292539
       },
       {
-        "lowerLimit" : 8,
-        "upperLimit" : 9,
+        "lower_limit" : 8,
+        "upper_limit" : 9,
         "percentage" : 0.26998794
       },
       {
-        "lowerLimit" : 9,
-        "upperLimit" : 10,
+        "lower_limit" : 9,
+        "upper_limit" : 10,
         "percentage" : 0.41753477
       }
     ]

--- a/server/src/main/resources/twitter-server/js/histogram-dom.js
+++ b/server/src/main/resources/twitter-server/js/histogram-dom.js
@@ -143,7 +143,7 @@ function refreshHistogram(updatedValues) {
   addColumns();
   for (var i = 0; i < updatedValues.length; i++) {
     var p = updatedValues[i];
-    var midpoint = (p.lowerLimit + p.upperLimit) / 2;
+    var midpoint = (p.lower_limit + p.upper_limit) / 2;
     data.addRow([midpoint, p.percentage]);
   }
 }


### PR DESCRIPTION
Problem

The histograms admin endpoint was updated in c90fa00caeba to use
snake_case for field names. The same change missed updating
documentation for the endpoint and the JavaScript that supports
histograms in the admin interface.

Solution

Updated docs and JS code to use snake_case field names for upper and
lower limits of histogram buckets.