### PR TITLE
bad link readme.md 404 - Code of Conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ public API breaks and changes in runtime behavior.
 ## Contributing
 
 We feel that a welcoming community is important and we ask that you follow Twitter's
-[Open Source Code of Conduct](https://github.com/twitter/code-of-conduct/blob/release/code-of-conduct.md)
+[Open Source Code of Conduct](https://github.com/twitter/.github/blob/main/code-of-conduct.md)
 in all interactions with the community.
 
 The `release` branch of this repository contains the latest stable release of


### PR DESCRIPTION
Was: https://github.com/twitter/code-of-conduct/blob/release/code-of-conduct.md
Appears it should be: https://github.com/twitter/twitter-server/blob/release/CODE_OF_CONDUCT.md


Found using tool: https://github.com/MrCull/GitHub-Repo-ReadMe-Dead-Link-Finder