### PR TITLE
Fix to the broken link in Contributing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ public API breaks and changes in runtime behavior.
 ## Contributing
 
 We feel that a welcoming community is important and we ask that you follow Twitter's
-[Open Source Code of Conduct](https://github.com/twitter/code-of-conduct/blob/release/code-of-conduct.md)
+[Open Source Code of Conduct](https://github.com/twitter/.github/blob/main/code-of-conduct.md)
 in all interactions with the community.
 
 The `release` branch of this repository contains the latest stable release of


### PR DESCRIPTION
Just a fix to a small typo on the README.

Doesn't really matter but its always nice to have that up and running for future contributors.